### PR TITLE
Add support for --add and --sysroot options

### DIFF
--- a/Makefile.test
+++ b/Makefile.test
@@ -13,7 +13,7 @@ ${KERNEL}:
 	exit 1
 
 ostree-initrd.img: ostreeinit ostreeinit-mkinitrd
-	./ostreeinit-mkinitrd ostree-initrd.img ostreeinit
+	./ostreeinit-mkinitrd --init=ostreeinit ostree-initrd.img
 
 run: ${IMAGE} ${KERNEL}  ostree-initrd.img
 	qemu-system-x86_64 -nographic -kernel ${KERNEL} -initrd ostree-initrd.img -enable-kvm -m 2G -cpu host -drive file=${IMAGE},index=0,media=disk,format=qcow2,if=virtio,snapshot=off -append ${KARGS}

--- a/ostreeinit-mkinitrd
+++ b/ostreeinit-mkinitrd
@@ -3,6 +3,7 @@
 set -e
 
 OSTREEINIT="/usr/lib/ostreeinit/ostreeinit"
+extra_files=()
 
 usage() {
     if test "$#" -ne 0; then
@@ -11,11 +12,12 @@ usage() {
     fi
     echo "Usage: ostreeinit-mkinitrd [OPTION...] FILE"
     echo
-    echo " -h --help	Display usage"
-    echo " --init=FILE	Specify custom init binary"
+    echo " -h --help		Display usage"
+    echo " --init=FILE		Specify custom init binary"
+    echo " --add=FILE		Add file to initrd"
 }
 
-VALID_ARGS=$(getopt -o h --long help,init: -- "$@")
+VALID_ARGS=$(getopt -o h --long help,init:,add: -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1;
 fi
@@ -25,6 +27,15 @@ while [ : ]; do
   case "$1" in
     --init)
         OSTREEINIT="$2"
+        shift 2
+        ;;
+    --add)
+        if [ -f $2 ]; then
+            extra_files+=($2)
+        else
+            echo "No such file $2"
+            exit 1
+        fi
         shift 2
         ;;
     --) shift;
@@ -84,6 +95,9 @@ add_binary() {
     done
 }
 
+for file in "${extra_files[@]}"; do
+    add_file "$file"
+done
 
 add_file /proc
 add_file /sys

--- a/ostreeinit-mkinitrd
+++ b/ostreeinit-mkinitrd
@@ -109,12 +109,15 @@ for bin in $BINS; do
 done
 
 D=$(mktemp -d)
-cp $OSTREEINIT $D/init
 
-echo init  | cpio -D $D  -H newc -o -O $D/initrd
+# Add files
 for file in "${files[@]}"; do
     echo $file;
-done | cpio -D /  -L -H newc -o -A -O $D/initrd
+done | cpio -D /  -L -H newc -o -O $D/initrd
+
+# Add initrd
+cp $OSTREEINIT $D/init
+echo init  | cpio -D $D  -H newc -o -A -O $D/initrd
 
 lz4 -l -9 -c $D/initrd > $DEST
 

--- a/ostreeinit-mkinitrd
+++ b/ostreeinit-mkinitrd
@@ -5,6 +5,8 @@ set -e
 OSTREEINIT="/usr/lib/ostreeinit/ostreeinit"
 extra_files=()
 
+echoerr() { echo "$@" 1>&2; }
+
 usage() {
     if test "$#" -ne 0; then
         echo "$@"
@@ -33,7 +35,7 @@ while [ : ]; do
         if [ -f $2 ]; then
             extra_files+=($2)
         else
-            echo "No such file $2"
+            echoerr "No such file $2"
             exit 1
         fi
         shift 2
@@ -65,9 +67,12 @@ BINS=/usr/lib/ostree/ostree-prepare-root
 files=()
 declare -A filesDict
 
-run_ldd() {
-    ldd $1 | grep "=>" | awk "{ print \$3 }"
-    ldd $1 | grep -v "=>" | grep ld-linux | awk "{ print \$1 }"
+need_file() {
+    local file=$1
+    if [ "${filesDict[$file]}" != 1 ]; then
+        return 0
+    fi
+    return 1
 }
 
 add_file() {
@@ -87,20 +92,38 @@ add_parents() {
     done
 }
 
-add_binary() {
-    local bin=$1
-    add_file $bin
-    for dep in $(run_ldd $bin); do
-        add_file $dep
+LIB_DIRS="/lib64 /lib /usr/lib64 /usr/lib"
+
+list_deps() {
+    local file=$1
+    DEPS=$(readelf -d $file | grep "(NEEDED)" |  cut -d ":" -f 2 |  sed -e 's,\[,,g' -e 's,],,g' -e 's,[ ]*,,g')
+    for dep in $DEPS; do
+        local deppath=$(find -L $LIB_DIRS -name "${dep}" -maxdepth 1 -type f 2>/dev/null | head -1)
+        if [ "${deppath}" == "" ]; then
+            echoerr "Unable to find dependency $dep"
+            exit 1
+        fi
+        echo $deppath
     done
 }
 
-for file in "${extra_files[@]}"; do
-    add_file "$file"
-done
+add_binary() {
+    local bin=$1
+    add_file $bin
+    local deps=$(list_deps $bin)
+    for dep in $deps; do
+        if need_file $dep; then
+            add_binary $dep
+        fi
+    done
+}
 
 for bin in $BINS; do
     add_binary $bin
+done
+
+for file in "${extra_files[@]}"; do
+    add_file "$file"
 done
 
 D=$(mktemp -d)

--- a/ostreeinit-mkinitrd
+++ b/ostreeinit-mkinitrd
@@ -4,6 +4,7 @@ set -e
 
 OSTREEINIT="/usr/lib/ostreeinit/ostreeinit"
 extra_files=()
+SYSROOT=/
 
 echoerr() { echo "$@" 1>&2; }
 
@@ -17,9 +18,10 @@ usage() {
     echo " -h --help		Display usage"
     echo " --init=FILE		Specify custom init binary"
     echo " --add=FILE		Add file to initrd"
+    echo " --sysroot=PATH	Specify sysroot directory to collect files from"
 }
 
-VALID_ARGS=$(getopt -o h --long help,init:,add: -- "$@")
+VALID_ARGS=$(getopt -o h --long help,init:,add:,sysroot: -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1;
 fi
@@ -32,10 +34,14 @@ while [ : ]; do
         shift 2
         ;;
     --add)
-        if [ -f $2 ]; then
-            extra_files+=($2)
+        extra_files+=($2)
+        shift 2
+        ;;
+    --sysroot)
+        if [ -d $2 ]; then
+            SYSROOT="$2"
         else
-            echoerr "No such file $2"
+            echoerr "No such directory $2"
             exit 1
         fi
         shift 2
@@ -77,6 +83,10 @@ need_file() {
 
 add_file() {
     local file=$1
+    if [ ! -e $SYSROOT/$file ]; then
+        echoerr Missing expected file $SYSROOT/$file
+        exit 1
+    fi
     if [ "${filesDict[$file]}" != 1 ]; then
         add_parents $file
         filesDict[$file]=1
@@ -92,7 +102,7 @@ add_parents() {
     done
 }
 
-LIB_DIRS="/lib64 /lib /usr/lib64 /usr/lib"
+LIB_DIRS="$SYSROOT/lib64 $SYSROOT/lib $SYSROOT/usr/lib64 $SYSROOT/usr/lib"
 
 list_deps() {
     local file=$1
@@ -103,7 +113,7 @@ list_deps() {
             echoerr "Unable to find dependency $dep"
             exit 1
         fi
-        echo $deppath
+        echo ${deppath#$SYSROOT}
     done
 }
 
@@ -130,8 +140,8 @@ D=$(mktemp -d)
 
 # Add files
 for file in "${files[@]}"; do
-    echo $file;
-done | cpio -D /  -L -H newc -o -O $D/initrd
+    echo ${file#/};
+done | cpio -D $SYSROOT  -L -H newc -o -O $D/initrd
 
 # Add initrd
 cp $OSTREEINIT $D/init

--- a/ostreeinit-mkinitrd
+++ b/ostreeinit-mkinitrd
@@ -1,16 +1,53 @@
 #!/usr/bin/bash
 
+set -e
+
+OSTREEINIT="/usr/lib/ostreeinit/ostreeinit"
+
+usage() {
+    if test "$#" -ne 0; then
+        echo "$@"
+        echo
+    fi
+    echo "Usage: ostreeinit-mkinitrd [OPTION...] FILE"
+    echo
+    echo " -h --help	Display usage"
+    echo " --init=FILE	Specify custom init binary"
+}
+
+VALID_ARGS=$(getopt -o h --long help,init: -- "$@")
+if [[ $? -ne 0 ]]; then
+    exit 1;
+fi
+
+eval set -- "$VALID_ARGS"
+while [ : ]; do
+  case "$1" in
+    --init)
+        OSTREEINIT="$2"
+        shift 2
+        ;;
+    --) shift;
+        break
+        ;;
+    -h | --help)
+        usage
+        exit 0
+  esac
+done
+
+if [ "$#" -lt 1 ]; then
+    usage "Missing destination name"
+    exit 1
+fi
+
 DEST=$1
 shift
 
-OSTREEINIT="$1"
-if [ -z "$OSTREEINIT" ]; then
-    # Default to packaged file
-    OSTREEINIT="/usr/lib/ostreeinit/ostreeinit"
+if test "$#" -ne 0; then
+    usage "Unexpected commandline arguments: $@"
+    exit 1
 fi
-shift
-
-set -e
 
 BINS=/usr/lib/ostree/ostree-prepare-root
 

--- a/ostreeinit-mkinitrd
+++ b/ostreeinit-mkinitrd
@@ -99,11 +99,6 @@ for file in "${extra_files[@]}"; do
     add_file "$file"
 done
 
-add_file /proc
-add_file /sys
-add_file /dev
-add_file /run
-
 for bin in $BINS; do
     add_binary $bin
 done


### PR DESCRIPTION
This allows us to add things to the initd (modules, ostree keys) and to use a different set of files than the host (needed in osbuild).