### PR TITLE
Add dracut module and specfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 all: ostreeinit
 
-LIBDIR=/usr/lib/ostreeinit
-BINDIR=/usr/bin
+VERSION=0.1
+
+LIBDIR?=/usr/lib/ostreeinit
+BINDIR?=/usr/bin
+CFLAGS?=-O2 -Wall
 
 ostreeinit: ostreeinit.c
-	gcc -O2 -Wall ostreeinit.c -o ostreeinit
+	gcc $(CFLAGS) ostreeinit.c -o ostreeinit
 
 clean:
 	rm -f ostreeinit ostree-initrd.img
@@ -13,7 +16,11 @@ install: ostreeinit
 	mkdir -p $(DESTDIR)$(LIBDIR)
 	mkdir -p $(DESTDIR)$(BINDIR)
 	install -t $(DESTDIR)$(LIBDIR) ostreeinit
-	install -t $(DESTDIR)$(BINDIR) ostreeinit-mkinitrd
+	mkdir -p $(DESTDIR)/usr/lib/dracut/modules.d/50ostreeinit
+	install -t $(DESTDIR)/usr/lib/dracut/modules.d/50ostreeinit dracut/module-setup.sh
+
+dist:
+	git archive --prefix=ostreeinit-${VERSION}/ --output=ostreeinit-${VERSION}.tar.gz HEAD
 
 clang-format:
 	git ls-files | grep -Ee "\\.[hc]$$" | xargs clang-format -style=file -i

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+install() {
+    inst /usr/lib/ostree/ostree-prepare-root
+    inst /usr/lib/ostreeinit/ostreeinit /init
+
+    # Don't install bash
+    > "${initdir}/usr/bin/bash"
+}


### PR DESCRIPTION
With rpm installed you can create a single-module dracut initrd that uses ostreeinit. These are slightly larger at around 8MB instead of 7MB, but you get all the features of dracut like the ability to add files and select compression formats, etc.